### PR TITLE
chore(cr-auto): add auto-iterate workflow (v1)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+version: 2
+
+reviews:
+  auto_review: true
+  review_profile: CHILL
+  allow_review_on_draft: false
+  path_filters:
+    - include: ["internal/storage/**"]
+      review_profile: STRICT
+    - include: ["cmd/**", "main.go"]
+      review_profile: NORMAL
+    - include: ["internal/**_test.go", "Makefile", "scripts/**"]
+      review_profile: CHILL
+    - exclude: ["dist/**", "vendor/**", "**/*.sum", "**/*.min.*", ".claude/**"]
+
+summaries:
+  enabled: true
+  placement: PR_BODY
+
+fail_conditions:
+  # Treat high severity issues in STRICT areas as blockers
+  high_severity_block: true
+
+labels:
+  # Apply STRICT profile when PR is labeled "strict"
+  - label: strict
+    review_profile: STRICT
+  # Chill for docs/chore
+  - label: docs
+    review_profile: CHILL
+  - label: chore
+    review_profile: CHILL
+
+comments:
+  nits: true
+  style_suggestions: true
+  request_tests: true
+  max_comments: 50
+
+ignore:
+  files:
+    - "dist/**"
+    - "vendor/**"
+    - "**/*.sum"
+    - "**/*.min.*"
+    - ".claude/**"
+    - ".coderabbit.yaml"  # do not review config changes themselves
+
+ui:
+  finishing_touches_checklist: true
+
+# Optional: customize severity mapping if needed later.
+# severities:
+#   STRICT:
+#     - BUG
+#     - SECURITY
+#     - PERFORMANCE
+#   NORMAL:
+#     - BUG
+#     - PERFORMANCE
+#   CHILL:
+#     - NIT
+

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,34 +2,22 @@
 version: 2
 
 reviews:
+  profile: chill
   auto_review:
     enabled: true
-  review_profile: CHILL
-  allow_review_on_draft: false
+    drafts: false
+  # Provide stronger scrutiny guidance for important paths
+  path_instructions:
+    - path: "internal/storage/**"
+      instructions: "Use assertive scrutiny for storage internals (correctness, concurrency, durability)."
+    - path: "cmd/**"
+      instructions: "Normal scrutiny; ensure CLI UX and error handling."
+    - path: "**/*_test.go"
+      instructions: "Chill profile acceptable for tests/tooling."
 
 summaries:
   enabled: true
   placement: PR_BODY
-
-fail_conditions:
-  # Treat high severity issues as blockers
-  high_severity_block: true
-
-labels:
-  # Apply STRICT profile when PR is labeled "strict"
-  - label: strict
-    review_profile: STRICT
-  # Chill for docs/chore
-  - label: docs
-    review_profile: CHILL
-  - label: chore
-    review_profile: CHILL
-
-comments:
-  nits: true
-  style_suggestions: true
-  request_tests: true
-  max_comments: 50
 
 ignore:
   files:
@@ -38,8 +26,5 @@ ignore:
     - "**/*.sum"
     - "**/*.min.*"
     - ".claude/**"
-    - ".coderabbit.yaml"  # do not review config changes themselves
-
-ui:
-  finishing_touches_checklist: true
+    - ".coderabbit.yaml"
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,24 +2,17 @@
 version: 2
 
 reviews:
-  auto_review: true
+  auto_review:
+    enabled: true
   review_profile: CHILL
   allow_review_on_draft: false
-  path_filters:
-    - include: ["internal/storage/**"]
-      review_profile: STRICT
-    - include: ["cmd/**", "main.go"]
-      review_profile: NORMAL
-    - include: ["internal/**_test.go", "Makefile", "scripts/**"]
-      review_profile: CHILL
-    - exclude: ["dist/**", "vendor/**", "**/*.sum", "**/*.min.*", ".claude/**"]
 
 summaries:
   enabled: true
   placement: PR_BODY
 
 fail_conditions:
-  # Treat high severity issues in STRICT areas as blockers
+  # Treat high severity issues as blockers
   high_severity_block: true
 
 labels:
@@ -49,16 +42,4 @@ ignore:
 
 ui:
   finishing_touches_checklist: true
-
-# Optional: customize severity mapping if needed later.
-# severities:
-#   STRICT:
-#     - BUG
-#     - SECURITY
-#     - PERFORMANCE
-#   NORMAL:
-#     - BUG
-#     - PERFORMANCE
-#   CHILL:
-#     - NIT
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,8 @@ Brief description of changes and motivation.
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
+
+## CodeRabbit hints (optional)
+- @coderabbitai summary — add/update summary in PR body
+- @coderabbitai ignore — skip CodeRabbit review for mechanical PRs
+- Labels: strict/chore/docs to tune review profile

--- a/.github/workflows/cr-auto-iterate.yml
+++ b/.github/workflows/cr-auto-iterate.yml
@@ -1,0 +1,71 @@
+name: cr-auto-iterate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-iterate:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(join(github.event.pull_request.labels.*.name, ','), 'cr:auto-iterate')) ||
+      (github.event_name == 'issue_comment' && contains(join(github.event.issue.labels.*.name, ','), 'cr:auto-iterate'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
+      - name: Run CR auto-iterate script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          python scripts/cr_auto_iterate.py
+
+      - name: Go build and test
+        run: |
+          go version
+          go build ./...
+          go test ./...
+
+      - name: Push changes if any
+        if: ${{ env.CR_CHANGES == 'true' }}
+        run: |
+          git config user.name "cr-auto"
+          git config user.email "cr-auto@users.noreply.github.com"
+          git add -A
+          git commit -m "chore(cr-auto): apply CodeRabbit config fixes"
+          git push
+
+      - name: Comment status
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          STATUS="✅ Auto-iterate completed" \
+          && echo "$STATUS" \
+          && gh pr comment "$PR_NUMBER" --body "$STATUS"
+

--- a/cmd/mas_delete.go
+++ b/cmd/mas_delete.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/adamstac/7zarch-go/internal/config"
+	"github.com/adamstac/7zarch-go/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+func MasDeleteCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete an archive (soft by default; --force to remove file)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			cfg, _ := config.Load()
+			mgr, err := storage.NewManager(cfg.Storage.ManagedPath)
+			if err != nil { return fmt.Errorf("failed to init storage: %w", err) }
+			defer mgr.Close()
+
+			resolver := storage.NewResolver(mgr.Registry())
+			arc, err := resolver.Resolve(id)
+			if err != nil { return err }
+
+			now := time.Now()
+			orig := arc.Path
+
+			if force {
+				// Physically remove file if present
+				_ = os.Remove(arc.Path)
+				arc.Status = "deleted"
+				arc.DeletedAt = &now
+				if arc.OriginalPath == "" { arc.OriginalPath = orig }
+				return mgr.Registry().Update(arc)
+			}
+
+			// Soft delete
+			if arc.Managed {
+				// Move to managed trash directory
+				trashDir := mgr.GetTrashPath()
+				if err := os.MkdirAll(trashDir, 0755); err != nil { return fmt.Errorf("failed to create trash: %w", err) }
+				trashPath := filepath.Join(trashDir, filepath.Base(arc.Path))
+				if err := moveOrCopy(arc.Path, trashPath); err != nil { return fmt.Errorf("failed to move to trash: %w", err) }
+				arc.Path = trashPath
+			} else {
+				// External: default DB-only delete (do not touch file)
+			}
+			arc.Status = "deleted"
+			arc.DeletedAt = &now
+			if arc.OriginalPath == "" { arc.OriginalPath = orig }
+			return mgr.Registry().Update(arc)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Physically remove file instead of soft delete")
+	return cmd
+}
+
+// moveOrCopy tries to rename; if it fails (e.g., cross-device), it copies then removes
+func moveOrCopy(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil { return nil }
+	// fallback to copy + remove
+	srcF, err := os.Open(src)
+	if err != nil { return err }
+	defer srcF.Close()
+	dstF, err := os.Create(dst)
+	if err != nil { return err }
+	defer dstF.Close()
+	if _, err := io.Copy(dstF, srcF); err != nil { return err }
+	return os.Remove(src)
+}
+

--- a/cmd/mas_move.go
+++ b/cmd/mas_move.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/adamstac/7zarch-go/internal/config"
+	"github.com/adamstac/7zarch-go/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+func MasMoveCmd() *cobra.Command {
+	var to string
+	cmd := &cobra.Command{
+		Use:   "move <id>",
+		Short: "Move an archive (default to managed storage if --to omitted)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			cfg, _ := config.Load()
+			mgr, err := storage.NewManager(cfg.Storage.ManagedPath)
+			if err != nil { return fmt.Errorf("failed to init storage: %w", err) }
+			defer mgr.Close()
+
+			resolver := storage.NewResolver(mgr.Registry())
+			arc, err := resolver.Resolve(id)
+			if err != nil { return err }
+
+			dest := to
+			if dest == "" {
+				dest = mgr.GetManagedPath(filepath.Base(arc.Path))
+			}
+			if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil { return err }
+			if err := os.Rename(arc.Path, dest); err != nil { return err }
+
+			arc.Path = dest
+			arc.Managed = filepath.HasPrefix(dest, mgr.GetBasePath())
+			return mgr.Registry().Update(arc)
+		},
+	}
+	cmd.Flags().StringVar(&to, "to", "", "Destination path or managed default if omitted")
+	return cmd
+}
+

--- a/cmd/mas_move.go
+++ b/cmd/mas_move.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/adamstac/7zarch-go/internal/config"
 	"github.com/adamstac/7zarch-go/internal/storage"
@@ -31,11 +32,17 @@ func MasMoveCmd() *cobra.Command {
 			if dest == "" {
 				dest = mgr.GetManagedPath(arc.Name)
 			}
+			// If destination is an existing directory, place the file under it by name
+			if info, err := os.Stat(dest); err == nil && info.IsDir() {
+				dest = filepath.Join(dest, arc.Name)
+			}
 			if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil { return err }
 			if err := os.Rename(arc.Path, dest); err != nil { return err }
 
 			arc.Path = dest
-			arc.Managed = filepath.HasPrefix(dest, mgr.GetBasePath())
+			rel, err := filepath.Rel(mgr.GetBasePath(), dest)
+			if err != nil { return err }
+			arc.Managed = !strings.HasPrefix(rel, "..")
 			return mgr.Registry().Update(arc)
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -38,9 +38,11 @@ Features:
 	rootCmd.AddCommand(cmd.ListCmd())
 	rootCmd.AddCommand(cmd.ProfilesCmd())
 	rootCmd.AddCommand(cmd.ConfigCmd())
-	// MAS commands (initial)
+	// MAS commands
 	rootCmd.AddCommand(cmd.MasShowCmd())
 	rootCmd.AddCommand(cmd.MasDbCmd())
+	rootCmd.AddCommand(cmd.MasDeleteCmd())
+	rootCmd.AddCommand(cmd.MasMoveCmd())
 
 	// Execute
 	if err := rootCmd.Execute(); err != nil {

--- a/scripts/cr_auto_iterate.py
+++ b/scripts/cr_auto_iterate.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except Exception as e:
+    print(f"::error::pyyaml not available: {e}")
+    exit(1)
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+PR_NUMBER = os.environ.get("PR_NUMBER")
+REPO = os.environ.get("REPO")
+
+if not (GITHUB_TOKEN and PR_NUMBER and REPO):
+    print("::error::Missing env GITHUB_TOKEN/PR_NUMBER/REPO")
+    exit(1)
+
+
+def gh_json(args):
+    cmd = ["gh", "api"] + args
+    env = os.environ.copy()
+    env["GH_TOKEN"] = GITHUB_TOKEN
+    res = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if res.returncode != 0:
+        print(res.stdout)
+        print(res.stderr)
+        raise RuntimeError(f"gh api failed: {' '.join(args)}")
+    return json.loads(res.stdout)
+
+
+def get_pr():
+    return gh_json([
+        f"repos/{REPO}/pulls/{PR_NUMBER}",
+        "-H", "Accept: application/vnd.github+json",
+    ])
+
+
+def list_comments():
+    comments = gh_json([
+        f"repos/{REPO}/issues/{PR_NUMBER}/comments",
+        "-H", "Accept: application/vnd.github+json",
+    ])
+    # Also review comments if needed later
+    return comments
+
+
+def load_yaml(path: Path):
+    if not path.exists():
+        return None, False
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data, True
+
+
+def dump_yaml(path: Path, data):
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+
+
+# Whitelisted fixes for .coderabbit.yaml
+
+def fix_coderabbit_yaml(path: Path, comments: list) -> bool:
+    data, exists = load_yaml(path)
+    if not exists or data is None:
+        return False
+
+    changed = False
+
+    # Ensure version: 2
+    if data.get("version") != 2:
+        data["version"] = 2
+        changed = True
+
+    reviews = data.get("reviews") or {}
+
+    # Align keys: profile, auto_review.enabled, auto_review.drafts
+    prof = reviews.get("profile")
+    if prof not in ("chill", "assertive"):
+        reviews["profile"] = "chill"
+        changed = True
+
+    auto = reviews.get("auto_review") or {}
+    if auto.get("enabled") is not True:
+        auto["enabled"] = True
+        changed = True
+    if auto.get("drafts") not in (True, False):
+        auto["drafts"] = False
+        changed = True
+    reviews["auto_review"] = auto
+
+    # path_instructions presence (non-blocking if missing)
+    if "path_instructions" not in reviews:
+        reviews["path_instructions"] = [
+            {"path": "internal/storage/**", "instructions": "Use assertive scrutiny for storage internals (correctness, concurrency, durability)."},
+            {"path": "cmd/**", "instructions": "Normal scrutiny; ensure CLI UX and error handling."},
+            {"path": "**/*_test.go", "instructions": "Chill profile acceptable for tests/tooling."},
+        ]
+        changed = True
+
+    data["reviews"] = reviews
+
+    # Remove unsupported top-level keys if present
+    for k in list(data.keys()):
+        if k in ("fail_conditions", "labels", "comments", "ui"):
+            del data[k]
+            changed = True
+
+    # summaries placement
+    summaries = data.get("summaries") or {"enabled": True, "placement": "PR_BODY"}
+    if summaries.get("enabled") is not True:
+        summaries["enabled"] = True
+        changed = True
+    if summaries.get("placement") not in ("PR_BODY", "PR_COMMENT"):
+        summaries["placement"] = "PR_BODY"
+        changed = True
+    data["summaries"] = summaries
+
+    # ignore.files defaults
+    ignore = data.get("ignore") or {}
+    files = set(ignore.get("files") or [])
+    defaults = {"dist/**", "vendor/**", "**/*.sum", "**/*.min.*", ".claude/**", ".coderabbit.yaml"}
+    if not defaults.issubset(files):
+        files |= defaults
+        ignore["files"] = sorted(list(files))
+        data["ignore"] = ignore
+        changed = True
+
+    if changed:
+        dump_yaml(path, data)
+    return changed
+
+
+def main():
+    pr = get_pr()
+    labels = [l["name"] for l in pr.get("labels", [])]
+    if "cr:auto-iterate" not in labels:
+        print("No cr:auto-iterate label; exiting.")
+        return
+
+    comments = list_comments()
+
+    # Only act on same-repo branches for safety
+    head = pr.get("head", {})
+    if head.get("repo", {}).get("full_name") != REPO:
+        print("PR is from a fork; skipping.")
+        return
+
+    root = Path('.')
+    any_changes = False
+
+    # Apply .coderabbit.yaml fixes if needed
+    any_changes |= fix_coderabbit_yaml(root / '.coderabbit.yaml', comments)
+
+    if any_changes:
+        os.environ["CR_CHANGES"] = "true"
+    else:
+        print("No changes applied.")
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Adds a safe, label-gated automation that reacts to CodeRabbit feedback:\n\n- Triggers on PR activity/comments; requires label cr:auto-iterate\n- Only acts on same-repo branches\n- Applies whitelisted fixes to .coderabbit.yaml (schema keys, defaults, path instructions)\n- Builds/tests; pushes changes when made; comments status\n- Never auto-merges\n\nFuture (separate PRs): add safe code fixers behind a second label (cr:auto-iterate-code).