### PR TITLE
docs: 7EPs/API sync + Trash placeholders

### DIFF
--- a/docs/7eps/7ep-0004-mas-foundation.md
+++ b/docs/7eps/7ep-0004-mas-foundation.md
@@ -1,18 +1,10 @@
 # 7EP-0004: MAS Foundation Implementation
 
-<<<<<<< HEAD
-**Status:** Draft
+**Status:** ✅ Completed (100%)
 **Author(s):** Claude Code (CC)
 **Assignment:** AC (Primary), CC (Supporting)
 **Difficulty:** 4 (complex - foundational system with multiple interdependent components)
 **Created:** 2025-08-12
-**Updated:** 2025-08-12
-=======
-**Status:** ✅ Completed (100%)  
-**Author(s):** Claude Code (CC)  
-**Assignment:** AC (Primary), CC (Supporting)  
-**Difficulty:** 4 (complex - foundational system with multiple interdependent components)  
-**Created:** 2025-08-12  
 **Updated:** 2025-08-12
 
 ## Current Status (August 12, 2025)
@@ -37,10 +29,9 @@
 - ✅ Comprehensive benchmark suite with 1K-10K archive datasets
 - ✅ All performance requirements exceeded by significant margins
 - ✅ Resolution: <1ms (target <50ms) - up to 2,941x faster
-- ✅ List filtering: ~35ms (target <200ms) - 5.5-6.25x faster  
+- ✅ List filtering: ~35ms (target <200ms) - 5.5-6.25x faster
 - ✅ Show command: <1ms (target <100ms) - up to 5,882x faster
-- ✅ O(1) scaling confirmed across all archive counts  
->>>>>>> origin/main
+- ✅ O(1) scaling confirmed across all archive counts
 
 ## Executive Summary
 
@@ -137,7 +128,7 @@ func (r *Resolver) HandleAmbiguous(err *AmbiguousIDError) (*Archive, error) {
 func runMasShow(cmd *cobra.Command, args []string) error {
     resolver := storage.NewResolver(registry)
 
-    archive, err := resolver.ResolveID(args[0])
+    archive, err := resolver.Resolve(args[0])
     if err != nil {
         return handleResolutionError(err)
     }

--- a/docs/7eps/7ep-0006-minimal-performance-testing.md
+++ b/docs/7eps/7ep-0006-minimal-performance-testing.md
@@ -130,7 +130,7 @@ func BenchmarkULIDResolution(b *testing.B) {
             for i := 0; i < b.N; i++ {
                 archive := archives[i%len(archives)]
                 id := tc.getID(archive)
-                _, err := resolver.ResolveID(id)
+                _, err := resolver.Resolve(id)
                 // Allow AmbiguousIDError for 4-char prefixes
                 if err != nil && !isAmbiguousError(err) {
                     b.Fatalf("Resolution failed: %v", err)

--- a/docs/7eps/index.md
+++ b/docs/7eps/index.md
@@ -32,16 +32,6 @@ A 7EP is a design document that provides:
 
 ## Current 7EPs
 
-<<<<<<< HEAD
-| 7EP | Title | Status | Assignee | Area | Difficulty | Created | Updated |
-|-----|-------|--------|----------|------|------------|---------|---------|
-| [0001](7ep-0001-trash-management.md) | Trash Management System | 🟡 Draft | AC | MAS | 3 | 2025-08-11 | 2025-08-12 |
-| [0002](7ep-0002-ci-integration.md) | CI Integration & Automation | 🟡 Draft | CC | CI | 2 | 2025-08-12 | 2025-08-12 |
-| [0003](7ep-0003-database-migrations.md) | Database Migrations & Schema Management | 🟡 Draft | AC | Registry | 2 | 2025-08-12 | 2025-08-12 |
-| [0004](7ep-0004-mas-foundation.md) | MAS Foundation Implementation | 🟡 Draft | AC | MAS | 4 | 2025-08-12 | 2025-08-12 |
-| [0005](7ep-0005-test-dataset-system.md) | Test Dataset System | 🟡 Draft | AC | Testing | 2 | 2025-08-12 | 2025-08-12 |
-| [0006](7ep-0006-minimal-performance-testing.md) | Minimal Performance Testing | 🟡 Draft | AC | Testing | 2 | 2025-08-12 | 2025-08-12 |
-=======
 | 7EP | Title | Status | Assignee | Difficulty | Created |
 |-----|-------|--------|----------|------------|---------|
 | [0001](7ep-0001-trash-management.md) | Trash Management System | 🟢 Ready | AC | 3 | 2025-08-11 |
@@ -51,7 +41,6 @@ A 7EP is a design document that provides:
 | [0005](7ep-0005-test-dataset-system.md) | Comprehensive Test Dataset System | 🟡 Draft | CC | 3 | 2025-08-12 |
 | [0006](7ep-0006-minimal-performance-testing.md) | Minimal Performance Testing for 7EP-0004 | ✅ Completed | CC | 1 | 2025-08-12 |
 | [0007](7ep-0007-enhanced-mas-operations.md) | Enhanced MAS Operations | 🟡 Draft | AC/CC | 3 | 2025-08-12 |
->>>>>>> origin/main
 
 ## How to Contribute
 

--- a/docs/reference/commands/trash.md
+++ b/docs/reference/commands/trash.md
@@ -1,0 +1,41 @@
+# Trash Management (Coming Soon)
+
+Note: This feature is being implemented in PR #10 and is not yet available on main.
+
+## restore
+Restore a deleted archive back to its original location (or managed path).
+
+Usage:
+
+```
+7zarch-go restore <id> [--force] [--dry-run]
+```
+
+- --force: overwrite destination if it exists
+- --dry-run: show actions without making changes
+
+## trash list
+List deleted archives with retention countdown.
+
+Usage:
+```
+7zarch-go trash list [--within-days N] [--before YYYY-MM-DD] [--json]
+```
+
+- --within-days: only show items purging within N days
+- --before: only show items deleted before date
+- --json: machine-readable output
+
+## trash purge
+Permanently delete trashed archives that are eligible for purge.
+
+Usage:
+```
+7zarch-go trash purge [--all] [--within-days N] [--force] [--dry-run]
+```
+
+- --all: ignore retention and purge everything
+- --within-days: only purge items purging within N days
+- --force: skip confirmation prompts
+- --dry-run: show actions without making changes
+


### PR DESCRIPTION
Sync 7EPs with current implementation and add upcoming Trash command docs.\n\n- 7EP-0004: remove conflict markers; use Resolver.Resolve; call out min prefix 12 default and centralized error types\n- 7EP-0006: change sample to resolver.Resolve\n- 7EP index: keep main table style and contents\n- Add docs/reference/commands/trash.md with 'coming soon' note pending PR #10\n\nNo code changes; docs-only PR.